### PR TITLE
fix: gracefully handle rateLimit 404 and return consistent fallback

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -742,6 +742,7 @@ class IssuesProcessor {
         });
     }
     getRateLimit() {
+        var _a;
         return __awaiter(this, void 0, void 0, function* () {
             const logger = new logger_1.Logger();
             try {
@@ -749,7 +750,15 @@ class IssuesProcessor {
                 return new rate_limit_1.RateLimit(rateLimitResult.data.rate);
             }
             catch (error) {
-                logger.error(`Error when getting rateLimit: ${error.message}`);
+                if (error.status === 404 &&
+                    ((_a = error.message) === null || _a === void 0 ? void 0 : _a.includes('Rate limiting is not enabled'))) {
+                    logger.warning('Rate limiting is not enabled on this GHES instance. Proceeding without rate limit checks.');
+                    return undefined; // Gracefully skip rate limiting logic
+                }
+                else {
+                    logger.error(`Error when getting rateLimit: ${error.message}`);
+                    return undefined; // Ensure fallback return in all error paths
+                }
             }
         });
     }


### PR DESCRIPTION

This pull request enhances the error handling logic in the `getRateLimit` method of the `IssuesProcessor` class to improve robustness and clarity, especially for GitHub Enterprise Server (GHES) environments where rate limiting may not be enabled.

**Changes**

* **File**: `src/classes/issues-processor.ts`
* Updated the `catch` block in `getRateLimit()`:

  * Detects `404` errors with message `"Rate limiting is not enabled"`.
  * Logs a warning and skips rate limit logic by returning `undefined`.
* Ensured all error paths explicitly return `undefined` to satisfy the `Promise<IRateLimit | undefined>` return type and avoid type ambiguity.

**Related issue:**
Not applicable — this change is for internal validation only.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
