### PR TITLE
Permissions Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The configuration must be on the default branch and the default values will:
 - Close the stale issues and pull requests after 7 days of inactivity
 - If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart
 
-## **Recommended permissions**
+## Recommended permissions
 
 For the execution of this action, it must be able to fetch all issues and pull requests from your repository. This retrieval is performed using the [`listForRepo` endpoint](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues), which returns both **issues and pull requests**.
 Because GitHub models every pull request as an issue, this endpoint requires **Issues: read** permission—even if your workflow configuration only targets pull requests.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,15 @@ The configuration must be on the default branch and the default values will:
 - Close the stale issues and pull requests after 7 days of inactivity
 - If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart
 
-## Recommended permissions
+## **Recommended permissions**
 
-For the execution of this action, it must be able to fetch all issues and pull requests from your repository.  
-In addition, based on the provided configuration, the action could require more permission(s) (e.g.: add label, remove label, comment, close, delete branch, etc.).  
+For the execution of this action, it must be able to fetch all issues and pull requests from your repository. This retrieval is performed using the [`listForRepo` endpoint](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues), which returns both **issues and pull requests**.
+Because GitHub models every pull request as an issue, this endpoint requires **Issues: read** permission—even if your workflow configuration only targets pull requests.
+Missing this permission—particularly in private repositories—will cause the API call to fail with the error:
+
+> **Resource not accessible by integration**
+
+In addition, based on the provided configuration, the action could require more permission(s) (e.g.: add label, remove label, comment, close, delete branch, etc.).
 This can be achieved with the following [configuration in the action](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions) if the permissions are restricted:
 
 ```yaml


### PR DESCRIPTION
**Description:**
This pull request updates the documentation to clarify the permissions required for the action to function correctly. The main change is an expanded explanation of why the "Issues: read" permission is necessary, especially when working with pull requests, and what error users may encounter if it is missing.

Documentation improvements:

* Added details explaining that the [`listForRepo` endpoint](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues) is used to retrieve both issues and pull requests, and clarified that "Issues: read" permission is required even when only targeting pull requests.
* Included information about the "Resource not accessible by integration" error that occurs if the required permission is missing, particularly in private repositories.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
