### PR TITLE
Refined filtering for allowed issue types, removed verbose logs related to PRs, and updated the tests accordingly.

### DIFF
--- a/__tests__/only-issue-types.spec.ts
+++ b/__tests__/only-issue-types.spec.ts
@@ -74,6 +74,9 @@ describe('only-issue-types option', () => {
   });
   test('should process allowed issue types and skip PRs without logs', async () => {
     const infoSpy = jest.spyOn(core, 'info');
+    const groupSpy = jest.spyOn(core, 'group');
+    const warningSpy = jest.spyOn(core, 'warning');
+
     const opts: IIssuesProcessorOptions = {
       ...DefaultProcessorOptions,
       onlyIssueTypes: 'bug'
@@ -133,14 +136,22 @@ describe('only-issue-types option', () => {
       async () => new Date().toDateString()
     );
     await processor.processIssues(1);
+
     // Only the bug issue is processed
     expect(processor.staleIssues.map(i => i.title)).toEqual(['A bug issue']);
-    // PR is silently skipped — no logs should mention it
-    const allLogs = infoSpy.mock.calls
-      .map((c: string[]) => c.join(' '))
-      .join('\n');
-    expect(allLogs).not.toContain('pull request');
+
+    // PR is silently skipped — no logs should mention it across all logging methods
+    const infoLogs = infoSpy.mock.calls.map(c => c[0]).join('\n');
+    const warningLogs = warningSpy.mock.calls.map(c => c[0]).join('\n');
+    const groupLogs = groupSpy.mock.calls.map(c => c[0]).join('\n');
+    const allLogs = [infoLogs, warningLogs, groupLogs].join('\n');
+
+    // Case-insensitive regex handles variations and ANSI codes
+    expect(allLogs).not.toMatch(/pull request/i);
+
     infoSpy.mockRestore();
+    groupSpy.mockRestore();
+    warningSpy.mockRestore();
   });
 
   test('should process all issues and PRs if onlyIssueTypes is unset', async () => {

--- a/__tests__/only-issue-types.spec.ts
+++ b/__tests__/only-issue-types.spec.ts
@@ -4,6 +4,7 @@ import {IssuesProcessorMock} from './classes/issues-processor-mock';
 import {DefaultProcessorOptions} from './constants/default-processor-options';
 import {generateIssue} from './functions/generate-issue';
 import {alwaysFalseStateMock} from './classes/state-mock';
+import * as core from '@actions/core';
 
 describe('only-issue-types option', () => {
   test('should only process issues with allowed type', async () => {
@@ -71,7 +72,8 @@ describe('only-issue-types option', () => {
       'A question'
     ]);
   });
-  test('should only process allowed issue types and skip PRs', async () => {
+  test('should process allowed issue types and skip PRs without logs', async () => {
+    const infoSpy = jest.spyOn(core, 'info');
     const opts: IIssuesProcessorOptions = {
       ...DefaultProcessorOptions,
       onlyIssueTypes: 'bug'
@@ -131,12 +133,15 @@ describe('only-issue-types option', () => {
       async () => new Date().toDateString()
     );
     await processor.processIssues(1);
-    // The bug issue is allowed by onlyIssueTypes, the feature issue is skipped,
-    // and the PR is skipped because onlyIssueTypes only filters issues (not PRs)
+    // Only the bug issue is processed
     expect(processor.staleIssues.map(i => i.title)).toEqual(['A bug issue']);
+    // PR is silently skipped — no logs should mention it
+    const allLogs = infoSpy.mock.calls.map((c: string[]) => c.join(' ')).join('\n');
+    expect(allLogs).not.toContain('pull request');
+    infoSpy.mockRestore();
   });
 
-  test('should process all issues if onlyIssueTypes is unset', async () => {
+  test('should process all issues and PRs if onlyIssueTypes is unset', async () => {
     const opts: IIssuesProcessorOptions = {
       ...DefaultProcessorOptions,
       onlyIssueTypes: ''
@@ -171,6 +176,21 @@ describe('only-issue-types option', () => {
         undefined,
         [],
         'feature'
+      ),
+      generateIssue(
+        opts,
+        3,
+        'A pull request',
+        '2020-01-01T17:00:00Z',
+        '2020-01-01T17:00:00Z',
+        false,
+        true,
+        [],
+        false,
+        false,
+        undefined,
+        [],
+        'feature'
       )
     ];
     const processor = new IssuesProcessorMock(
@@ -183,7 +203,8 @@ describe('only-issue-types option', () => {
     await processor.processIssues(1);
     expect(processor.staleIssues.map(i => i.title)).toEqual([
       'A bug',
-      'A feature'
+      'A feature',
+      'A pull request'
     ]);
   });
 });

--- a/__tests__/only-issue-types.spec.ts
+++ b/__tests__/only-issue-types.spec.ts
@@ -136,7 +136,9 @@ describe('only-issue-types option', () => {
     // Only the bug issue is processed
     expect(processor.staleIssues.map(i => i.title)).toEqual(['A bug issue']);
     // PR is silently skipped — no logs should mention it
-    const allLogs = infoSpy.mock.calls.map((c: string[]) => c.join(' ')).join('\n');
+    const allLogs = infoSpy.mock.calls
+      .map((c: string[]) => c.join(' '))
+      .join('\n');
     expect(allLogs).not.toContain('pull request');
     infoSpy.mockRestore();
   });

--- a/__tests__/only-issue-types.spec.ts
+++ b/__tests__/only-issue-types.spec.ts
@@ -71,6 +71,70 @@ describe('only-issue-types option', () => {
       'A question'
     ]);
   });
+  test('should only process allowed issue types and skip PRs', async () => {
+    const opts: IIssuesProcessorOptions = {
+      ...DefaultProcessorOptions,
+      onlyIssueTypes: 'bug'
+    };
+    const TestIssueList: Issue[] = [
+      generateIssue(
+        opts,
+        1,
+        'A bug issue',
+        '2020-01-01T17:00:00Z',
+        '2020-01-01T17:00:00Z',
+        false,
+        false,
+        [],
+        false,
+        false,
+        undefined,
+        [],
+        'bug'
+      ),
+      generateIssue(
+        opts,
+        2,
+        'A feature issue',
+        '2020-01-01T17:00:00Z',
+        '2020-01-01T17:00:00Z',
+        false,
+        false,
+        [],
+        false,
+        false,
+        undefined,
+        [],
+        'feature'
+      ),
+      generateIssue(
+        opts,
+        3,
+        'A pull request',
+        '2020-01-01T17:00:00Z',
+        '2020-01-01T17:00:00Z',
+        false,
+        true,
+        [],
+        false,
+        false,
+        undefined,
+        [],
+        'feature'
+      )
+    ];
+    const processor = new IssuesProcessorMock(
+      opts,
+      alwaysFalseStateMock,
+      async p => (p === 1 ? TestIssueList : []),
+      async () => [],
+      async () => new Date().toDateString()
+    );
+    await processor.processIssues(1);
+    // The bug issue is allowed by onlyIssueTypes, the feature issue is skipped,
+    // and the PR is skipped because onlyIssueTypes only filters issues (not PRs)
+    expect(processor.staleIssues.map(i => i.title)).toEqual(['A bug issue']);
+  });
 
   test('should process all issues if onlyIssueTypes is unset', async () => {
     const opts: IIssuesProcessorOptions = {

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -257,10 +257,6 @@ export class IssuesProcessor {
     }
 
     if (this.options.onlyIssueTypes) {
-      if (issue.isPullRequest) {
-        IssuesProcessor._endIssueProcessing(issue);
-        return;
-      }
       const allowedTypes = this.options.onlyIssueTypes
         .split(',')
         .map(t => t.trim().toLowerCase())

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -148,6 +148,10 @@ export class IssuesProcessor {
       if (!this.operations.hasRemainingOperations()) {
         break;
       }
+      // Skip PRs silently when onlyIssueTypes is set
+      if (this.options.onlyIssueTypes && issue.isPullRequest) {
+        continue;
+      }
 
       const issueLogger: IssueLogger = new IssueLogger(issue);
       if (this.state.isIssueProcessed(issue)) {
@@ -253,6 +257,10 @@ export class IssuesProcessor {
     }
 
     if (this.options.onlyIssueTypes) {
+      if (issue.isPullRequest) {
+        IssuesProcessor._endIssueProcessing(issue);
+        return;
+      }
       const allowedTypes = this.options.onlyIssueTypes
         .split(',')
         .map(t => t.trim().toLowerCase())


### PR DESCRIPTION
**Description:**
This pull request enhances the handling of the `onlyIssueTypes` option in issue processing, specifically ensuring that pull requests (PRs) are silently skipped (without logging) when this option is set, and improves test coverage for this behavior. The changes also clarify that when `onlyIssueTypes` is unset, both issues and PRs are processed as before.

**Behavioral changes for `onlyIssueTypes`:**

* Updated `IssuesProcessor` to silently skip PRs when `onlyIssueTypes` is set, preventing any logging or processing for PRs in this mode. [[1]](diffhunk://#diff-93e32a46e13f11c2066be36506b0f153d7da2b6b8d787da9177c10692ce50fc5R151-R154) [[2]](diffhunk://#diff-93e32a46e13f11c2066be36506b0f153d7da2b6b8d787da9177c10692ce50fc5R260-R263)

**Test improvements:**

* Added a test case in `__tests__/only-issue-types.spec.ts` to verify that only allowed issue types are processed and PRs are skipped without logs when `onlyIssueTypes` is set.
* Modified test data and assertions to include PRs and ensure correct behavior when `onlyIssueTypes` is set or unset. [[1]](diffhunk://#diff-af691000f55dd6b9ba20bcbd3ffa508ba4e41150c8c0a0ce0d950d8c40980feaR179-R193) [[2]](diffhunk://#diff-af691000f55dd6b9ba20bcbd3ffa508ba4e41150c8c0a0ce0d950d8c40980feaL122-R207)
* Updated imports to support the new test logic.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
