### PR TITLE
Clarify 'only-issue-types' option applies to issues only

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,8 +569,7 @@ A comma separated list of allowed issue types. Only issues with a matching type 
 
 If unset (or an empty string), this option will not alter the stale workflow.
 
-> [!NOTE]
-> This option applies to **Issues only**. Since Pull Requests do not have a `type` field in GitHub's data model, **all PRs will be skipped entirely** when this option is set.
+> **Note**: This option applies to **Issues only**. Since Pull Requests do not have a `type` field in GitHub's data model, **all PRs will be skipped entirely** when this option is set.
 
 Default value: unset
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Every argument is optional.
 | [ignore-pr-updates](#ignore-pr-updates)                             | Override [ignore-updates](#ignore-updates) for PRs only                     |                       |
 | [include-only-assigned](#include-only-assigned)                     | Process only assigned issues                                                | `false`               |
 | [sort-by](#sort-by)                                                 | What to sort issues and PRs by                                              | `created`             |
-| [only-issue-types](#only-issue-types)                               | Only issues with a matching type are processed as stale/closed. Issues only — all PRs are skipped when set. |                       |
+| [only-issue-types](#only-issue-types)                               | Only issues with a matching type are processed as stale/closed. All PRs are skipped when this option is set. |                       |
 
 ### List of output options
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Every argument is optional.
 | [ignore-pr-updates](#ignore-pr-updates)                             | Override [ignore-updates](#ignore-updates) for PRs only                     |                       |
 | [include-only-assigned](#include-only-assigned)                     | Process only assigned issues                                                | `false`               |
 | [sort-by](#sort-by)                                                 | What to sort issues and PRs by                                              | `created`             |
-| [only-issue-types](#only-issue-types)                               | Only issues with a matching type are processed as stale/closed.             |                       |
+| [only-issue-types](#only-issue-types)                               | Only issues with a matching type are processed as stale/closed. Issues only — all PRs are skipped when set. |                       |
 
 ### List of output options
 
@@ -568,6 +568,9 @@ Default value: `created`
 A comma separated list of allowed issue types. Only issues with a matching type will be processed (e.g.: `bug,question`).
 
 If unset (or an empty string), this option will not alter the stale workflow.
+
+> [!WARNING]
+> This option applies to **Issues only**. Since Pull Requests do not have a `type` field in GitHub's data model, **all PRs will be skipped entirely** when this option is set.
 
 Default value: unset
 

--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ A comma separated list of allowed issue types. Only issues with a matching type 
 
 If unset (or an empty string), this option will not alter the stale workflow.
 
-> [!WARNING]
+> [!NOTE]
 > This option applies to **Issues only**. Since Pull Requests do not have a `type` field in GitHub's data model, **all PRs will be skipped entirely** when this option is set.
 
 Default value: unset

--- a/action.yml
+++ b/action.yml
@@ -105,11 +105,11 @@ inputs:
     default: ''
     required: false
   only-issue-labels:
-    description: 'Only issues with all of these labels are checked if stale. Defaults to `[]` (disabled) and can be a comma-separated list of labels. Override "only-labels" option regarding only the issues.'
+    description: 'Only issues with all of these labels are checked if stale. Defaults to `` (disabled) and can be a comma-separated list of labels. Override "only-labels" option regarding only the issues.'
     default: ''
     required: false
   only-pr-labels:
-    description: 'Only pull requests with all of these labels are checked if stale. Defaults to `[]` (disabled) and can be a comma-separated list of labels. Override "only-labels" option regarding only the pull requests.'
+    description: 'Only pull requests with all of these labels are checked if stale. Defaults to `` (disabled) and can be a comma-separated list of labels. Override "only-labels" option regarding only the pull requests.'
     default: ''
     required: false
   operations-per-run:
@@ -209,7 +209,7 @@ inputs:
     default: 'false'
     required: false
   only-issue-types:
-    description: 'Only issues with a matching type are processed as stale/closed. Since Pull Requests do not have a type in GitHub''s data model, all PRs will be skipped when this option is set. Defaults to `[]` (disabled) and can be a comma-separated list of issue types.'
+    description: 'Only issues with a matching type are processed as stale/closed. Since Pull Requests do not have a type in GitHub''s data model, all PRs will be skipped when this option is set. Defaults to `` (disabled) and can be a comma-separated list of issue types.'
     default: ''
     required: false
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -209,7 +209,7 @@ inputs:
     default: 'false'
     required: false
   only-issue-types:
-    description: 'Only issues with a matching type are processed as stale/closed. Defaults to `[]` (disabled) and can be a comma-separated list of issue types.'
+    description: 'Only issues with a matching type are processed as stale/closed. Since Pull Requests do not have a type in GitHub''s data model, all PRs will be skipped when this option is set. Defaults to `[]` (disabled) and can be a comma-separated list of issue types.'
     default: ''
     required: false
 outputs:


### PR DESCRIPTION
**Description:**
This pull request clarifies the behavior of the `only-issue-types` option to make it clear that it applies exclusively to issues and not to pull requests. When this option is set, all pull requests will be skipped, as PRs do not have a `type` field in GitHub's data model.

**Documentation updates:**

* Updated the description of the `only-issue-types` input in `action.yml` to explain that all PRs are skipped when this option is set, since PRs lack a `type` field.
* Enhanced the `README.md` to clarify in both the options table and the detailed section that `only-issue-types` applies only to issues and all PRs will be skipped if set. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R109) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R572-R573)

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
